### PR TITLE
Improvements to DwC converter

### DIFF
--- a/pyinaturalist_convert/__init__.py
+++ b/pyinaturalist_convert/__init__.py
@@ -2,7 +2,7 @@
 from .constants import *
 from .converters import *
 from .csv import load_csv_exports
-from .dwc import to_dwc
+from .dwc import to_dwc, observation_to_dwc_record, taxon_to_dwc_record
 from .dwca import *
 from .geojson import to_geojson
 from .odp import download_odp_metadata

--- a/pyinaturalist_convert/__init__.py
+++ b/pyinaturalist_convert/__init__.py
@@ -2,7 +2,7 @@
 from .constants import *
 from .converters import *
 from .csv import load_csv_exports
-from .dwc import to_dwc, observation_to_dwc_record, taxon_to_dwc_record
+from .dwc import to_dwc
 from .dwca import *
 from .geojson import to_geojson
 from .odp import download_odp_metadata

--- a/pyinaturalist_convert/dwc.py
+++ b/pyinaturalist_convert/dwc.py
@@ -129,7 +129,7 @@ def to_dwc(observations: AnyObservations, filename: PathOrStr = None) -> Optiona
         filename: Path to write XML output
 
     Returns:
-        If no filename is provided, records will be returned a list of dictionaries.
+        If no filename is provided, records will be returned as a list of dictionaries.
     """
     import xmltodict
 
@@ -211,6 +211,8 @@ def photo_to_data_object(observation: Dict, photo: Dict) -> Dict:
     for dwc_field, value in PHOTO_CONSTANTS.items():
         dwc_photo[dwc_field] = value
 
+    # TODO: pending fix in BaseModel.from_json()
+    photo.pop('_url_format', None)
     photo_obj = Photo.from_json(photo)
     dwc_photo['ac:accessURI'] = photo_obj.square_url
     dwc_photo['media:thumbnailURL'] = photo_obj.thumbnail_url

--- a/pyinaturalist_convert/dwc.py
+++ b/pyinaturalist_convert/dwc.py
@@ -133,22 +133,23 @@ def to_dwc(observations: AnyObservations, filename: PathOrStr = None) -> Optiona
     Returns:
         If no filename is provided, records will be returned as a list of dictionaries.
     """
-    import xmltodict
-
     records = [observation_to_dwc_record(obs) for obs in flatten_observations(observations)]
-    if not filename:
+    if filename:
+        write(get_dwc_record_set(records), filename)
+        return None
+    else:
         return records
 
-    record_set = get_dwc_record_set(records)
-    record_xml = xmltodict.unparse(record_set, pretty=True, indent=' ' * 4)
-    write(record_xml, filename)
-    return None
 
+def get_dwc_record_set(records: List[Dict]) -> str:
+    """Make a DwC RecordSet as an XML string, including namespaces and the provided observation
+    records
+    """
+    import xmltodict
 
-def get_dwc_record_set(records: List[Dict]) -> Dict:
-    """Make a DwC RecordSet including XML namespaces and the provided observation records"""
     namespaces = {f'@{k}': v for k, v in XML_NAMESPACES.items()}
-    return {'dwr:SimpleDarwinRecordSet': {**namespaces, 'dwr:SimpleDarwinRecord': records}}
+    records = {**namespaces, 'dwr:SimpleDarwinRecord': records}  # type: ignore
+    return xmltodict.unparse({'dwr:SimpleDarwinRecordSet': records}, pretty=True, indent=' ' * 4)
 
 
 def observation_to_dwc_record(observation: Dict) -> Dict:

--- a/pyinaturalist_convert/dwc.py
+++ b/pyinaturalist_convert/dwc.py
@@ -16,7 +16,7 @@ from flatten_dict import flatten
 from pyinaturalist import Photo, get_taxa_by_id
 
 from .constants import PathOrStr
-from .converters import AnyObservations, flatten_observations, write
+from .converters import AnyObservations, AnyTaxa, flatten_observations, to_dict_list, write
 
 # Top-level fields from observation JSON
 OBSERVATION_FIELDS = {
@@ -123,17 +123,23 @@ XML_NAMESPACES = {
 #   dwc:stateProvince:This may require a separate query to /places endpoint, so skipping for now
 
 
-def to_dwc(observations: AnyObservations, filename: PathOrStr = None) -> Optional[List[Dict]]:
+def to_dwc(
+    observations: AnyObservations = None, filename: PathOrStr = None, taxa: AnyTaxa = None
+) -> Optional[List[Dict]]:
     """Convert observations into to a Simple Darwin Core RecordSet.
 
     Args:
         observations: Observation records to convert
         filename: Path to write XML output
+        taxa: Convert taxon records instead of observations
 
     Returns:
         If no filename is provided, records will be returned as a list of dictionaries.
     """
-    records = [observation_to_dwc_record(obs) for obs in flatten_observations(observations)]
+    if observations:
+        records = [observation_to_dwc_record(obs) for obs in flatten_observations(observations)]
+    elif taxa:
+        records = [taxon_to_dwc_record(taxon) for taxon in to_dict_list(taxa)]
     if filename:
         write(get_dwc_record_set(records), filename)
         return None

--- a/pyinaturalist_convert/dwc.py
+++ b/pyinaturalist_convert/dwc.py
@@ -190,6 +190,19 @@ def observation_to_dwc_record(observation: Dict) -> Dict:
     return dwc_record
 
 
+def taxon_to_dwc_record(taxon: Dict) -> Dict:
+    """Translate a taxon from API results to a partial DwC record (taxonomy terms only)"""
+    # Translate 'ancestors' from API results to 'rank': 'name' fields
+    for ancestor in taxon['ancestors'] + [taxon]:
+        taxon[ancestor['rank']] = ancestor['name']
+
+    return {
+        dwc_field: taxon.get(inat_field.replace('taxon.', ''))
+        for inat_field, dwc_field in OBSERVATION_FIELDS.items()
+        if inat_field.startswith('taxon.')
+    }
+
+
 def format_geoprivacy(observation: Dict) -> Optional[str]:
     if observation['geoprivacy'] == 'obscured':
         return (

--- a/pyinaturalist_convert/dwca.py
+++ b/pyinaturalist_convert/dwca.py
@@ -4,7 +4,7 @@ from os.path import basename, splitext
 from pathlib import Path
 from typing import Dict
 
-from .constants import DATA_DIR, DWCA_DIR, DWCA_TAXA_URL, DWCA_URL, PathOrStr
+from .constants import DATA_DIR, DWCA_TAXA_URL, DWCA_URL, PathOrStr
 from .download import check_download, download_file, unzip_progress
 from .sqlite import load_table
 

--- a/pyinaturalist_convert/geojson.py
+++ b/pyinaturalist_convert/geojson.py
@@ -3,7 +3,7 @@ from typing import List
 from geojson import Feature, FeatureCollection, Point
 from pyinaturalist.constants import ResponseResult
 
-from .converters import AnyObservations, ensure_list, flatten_observation
+from .converters import AnyObservations, flatten_observation, to_dict_list
 
 # Basic observation attributes to include by default in geojson responses
 DEFAULT_OBSERVATION_ATTRS = [
@@ -34,7 +34,7 @@ def to_geojson(
     """
     try:
         feature_collection = FeatureCollection(
-            [_to_geojson_feature(obs, properties) for obs in ensure_list(observations)]
+            [_to_geojson_feature(obs, properties) for obs in to_dict_list(observations)]
         )
     except Exception as err:
         print(err)

--- a/pyinaturalist_convert/gpx.py
+++ b/pyinaturalist_convert/gpx.py
@@ -5,7 +5,7 @@ from pyinaturalist import Observation
 from pyinaturalist.constants import ResponseResult
 from pyinaturalist.converters import convert_observation_timestamps
 
-from .converters import AnyObservations, ensure_list, write
+from .converters import AnyObservations, to_dict_list, write
 
 logger = getLogger(__name__)
 
@@ -37,7 +37,7 @@ def to_gpx(observations: AnyObservations, filename: str = None, track: bool = Tr
         GPX XML as a string
     """
     gpx = GPX()
-    points = [to_gpx_point(obs, track=track) for obs in ensure_list(observations)]
+    points = [to_gpx_point(obs, track=track) for obs in to_dict_list(observations)]
 
     if track:
         gpx_track = GPXTrack()

--- a/test/sample_data/observations.dwc
+++ b/test/sample_data/observations.dwc
@@ -31,8 +31,7 @@
         <dwc:identifiedBy>Alex Bairstow</dwc:identifiedBy>
         <dwc:identifiedByID></dwc:identifiedByID>
         <eol:dataObject>
-            <dcterms:identifier>https://inaturalist-open-data.s3.amazonaws.com/photos/72181173/square.jpeg</dcterms:identifier>
-            <ac:furtherInformationURL>https://inaturalist-open-data.s3.amazonaws.com/photos/72181173/square.jpeg</ac:furtherInformationURL>
+            <dcterms:identifier>72181173</dcterms:identifier>
             <ac:derivedFrom>https://inaturalist-open-data.s3.amazonaws.com/photos/72181173/square.jpeg</ac:derivedFrom>
             <dcterms:rights>(c) Alex Bairstow, some rights reserved (CC BY-NC)</dcterms:rights>
             <dcterms:description>x13 seen this morning </dcterms:description>
@@ -41,14 +40,14 @@
             <xap:Owner>Alex Bairstow</xap:Owner>
             <dcterms:publisher>iNaturalist</dcterms:publisher>
             <dcterms:type>http://purl.org/dc/dcmitype/StillImage</dcterms:type>
-            <ac:accessURI>https://inaturalist-open-data.s3.amazonaws.com/photos/72181173/square.jpeg</ac:accessURI>
+            <ac:accessURI>https://inaturalist-open-data.s3.amazonaws.com/photos/72181173/original.jpeg</ac:accessURI>
+            <ac:furtherInformationURL>https://www.inaturalist.org/photos/72181173</ac:furtherInformationURL>
             <media:thumbnailURL>https://inaturalist-open-data.s3.amazonaws.com/photos/72181173/square.jpeg</media:thumbnailURL>
             <dcterms:format>image/jpeg</dcterms:format>
             <xap:UsageTerms>http://creativecommons.org/licenses/by-nc/4.0</xap:UsageTerms>
         </eol:dataObject>
         <eol:dataObject>
-            <dcterms:identifier>https://inaturalist-open-data.s3.amazonaws.com/photos/72180675/square.jpeg</dcterms:identifier>
-            <ac:furtherInformationURL>https://inaturalist-open-data.s3.amazonaws.com/photos/72180675/square.jpeg</ac:furtherInformationURL>
+            <dcterms:identifier>72180675</dcterms:identifier>
             <ac:derivedFrom>https://inaturalist-open-data.s3.amazonaws.com/photos/72180675/square.jpeg</ac:derivedFrom>
             <dcterms:rights>(c) Alex Bairstow, some rights reserved (CC BY-NC)</dcterms:rights>
             <dcterms:description>x13 seen this morning </dcterms:description>
@@ -57,7 +56,8 @@
             <xap:Owner>Alex Bairstow</xap:Owner>
             <dcterms:publisher>iNaturalist</dcterms:publisher>
             <dcterms:type>http://purl.org/dc/dcmitype/StillImage</dcterms:type>
-            <ac:accessURI>https://inaturalist-open-data.s3.amazonaws.com/photos/72180675/square.jpeg</ac:accessURI>
+            <ac:accessURI>https://inaturalist-open-data.s3.amazonaws.com/photos/72180675/original.jpeg</ac:accessURI>
+            <ac:furtherInformationURL>https://www.inaturalist.org/photos/72180675</ac:furtherInformationURL>
             <media:thumbnailURL>https://inaturalist-open-data.s3.amazonaws.com/photos/72180675/square.jpeg</media:thumbnailURL>
             <dcterms:format>image/jpeg</dcterms:format>
             <xap:UsageTerms>http://creativecommons.org/licenses/by-nc/4.0</xap:UsageTerms>
@@ -73,5 +73,6 @@
         <dwc:datasetName>iNaturalist research-grade observations</dwc:datasetName>
         <dwc:eventDate>2020-05-09T06:01:00-08:00</dwc:eventDate>
         <dwc:eventTime>06:01-0800</dwc:eventTime>
+        <dwc:informationWithheld></dwc:informationWithheld>
     </dwr:SimpleDarwinRecord>
 </dwr:SimpleDarwinRecordSet>

--- a/test/test_dwc.py
+++ b/test/test_dwc.py
@@ -1,9 +1,9 @@
 from pyinaturalist import get_observations
 
-from pyinaturalist_convert import taxon_to_dwc_record, to_dwc
+from pyinaturalist_convert import to_dwc
 
 
-def test_to_dwc():
+def test_observation_to_dwc():
     """Get a test observation, and convert it to DwC"""
     response = get_observations(id=45524803)
     observation = response['results'][0]
@@ -20,7 +20,7 @@ def test_to_dwc():
     assert dwc_record['dwc:scientificName'] == 'Dirona picta'
 
 
-def test_taxon_to_dwc_record():
+def test_taxon_to_dwc():
     taxon = {
         'id': 12345,
         'rank': 'species',
@@ -36,7 +36,7 @@ def test_taxon_to_dwc_record():
         ],
     }
 
-    dwc_record = taxon_to_dwc_record(taxon)
+    dwc_record = to_dwc(taxa=[taxon])[0]
     assert dwc_record == {
         'dwc:taxonID': 12345,
         'dwc:taxonRank': 'species',

--- a/test/test_dwc.py
+++ b/test/test_dwc.py
@@ -1,9 +1,9 @@
 from pyinaturalist import get_observations
 
-from pyinaturalist_convert import to_dwc
+from pyinaturalist_convert import taxon_to_dwc_record, to_dwc
 
 
-def test_observation_to_dwc():
+def test_to_dwc():
     """Get a test observation, and convert it to DwC"""
     response = get_observations(id=45524803)
     observation = response['results'][0]
@@ -18,3 +18,33 @@ def test_observation_to_dwc():
     assert dwc_record['dwc:decimalLongitude'] == -117.2815829044
     assert dwc_record['dwc:eventDate'] == '2020-05-09T06:01:00-08:00'
     assert dwc_record['dwc:scientificName'] == 'Dirona picta'
+
+
+def test_taxon_to_dwc_record():
+    taxon = {
+        'id': 12345,
+        'rank': 'species',
+        'name': 'Philemon buceroides',
+        'ancestors': [
+            {'rank': 'kingdom', 'name': 'Animalia'},
+            {'rank': 'phylum', 'name': 'Chordata'},
+            {'rank': 'class', 'name': 'Aves'},
+            {'rank': 'order', 'name': 'Passeriformes'},
+            {'rank': 'family', 'name': 'Meliphagidae'},
+            {'rank': 'genus', 'name': 'Philemon'},
+            {'rank': '', 'name': ''},
+        ],
+    }
+
+    dwc_record = taxon_to_dwc_record(taxon)
+    assert dwc_record == {
+        'dwc:taxonID': 12345,
+        'dwc:taxonRank': 'species',
+        'dwc:scientificName': 'Philemon buceroides',
+        'dwc:kingdom': 'Animalia',
+        'dwc:phylum': 'Chordata',
+        'dwc:class': 'Aves',
+        'dwc:order': 'Passeriformes',
+        'dwc:family': 'Meliphagidae',
+        'dwc:genus': 'Philemon',
+    }


### PR DESCRIPTION
* Make use of new Observation model features                                                      
* Update dcterms:identifier, ac:furtherInformationURL, and ac:accessURI for photos in a DwC record
* Don't import xmltodict if not writing DwC records to a file                                     
* Add function to translate a taxon from API results into basic DwC taxonomy terms                
* Allow passing taxa instead of observations to to_dwc()                                          
