### PR TITLE
Add 'pyinat' namespace alias

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -67,14 +67,14 @@ lxml = ["lxml"]
 
 [[package]]
 name = "boto3"
-version = "1.22.9"
+version = "1.22.13"
 description = "The AWS SDK for Python"
 category = "main"
 optional = true
 python-versions = ">= 3.6"
 
 [package.dependencies]
-botocore = ">=1.25.9,<1.26.0"
+botocore = ">=1.25.13,<1.26.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.5.0,<0.6.0"
 
@@ -83,7 +83,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.25.9"
+version = "1.25.13"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = true
@@ -677,7 +677,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "pyinaturalist"
-version = "0.17.0.dev5"
+version = "0.17.0.dev7"
 description = "iNaturalist API client for python"
 category = "main"
 optional = false
@@ -691,7 +691,7 @@ python-dateutil = ">=2.0"
 python-forge = ">=18.6"
 requests = ">=2.22"
 requests-cache = ">=1.0.0a0"
-requests-ratelimiter = ">=0.3.1"
+requests-ratelimiter = ">=0.3.2"
 rich = ">=10.9"
 
 [package.extras]
@@ -699,7 +699,7 @@ docs = ["furo (>=2022.2.14.1,<2023.0.0.0)", "ipython (>=7.25.0,<8.0.0)", "linkif
 
 [[package]]
 name = "pyparsing"
-version = "3.0.8"
+version = "3.0.9"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
 category = "main"
 optional = false
@@ -890,7 +890,7 @@ docs = ["furo (>=2022.4,<2023.0)", "linkify-it-py (>=2.0,<3.0)", "myst-parser (>
 
 [[package]]
 name = "requests-ratelimiter"
-version = "0.3.1"
+version = "0.3.2"
 description = "Rate-limiting for the requests library"
 category = "main"
 optional = false
@@ -1303,7 +1303,7 @@ xlsx = ["openpyxl"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "7e4a5977984517e7bced7fbc73450ddd083671b9dc5618f181c8956b2a7878d5"
+content-hash = "ff206632d9b2516e4d4608a06f406a47ec19eea629d287d401d44d3b4d435ee6"
 
 [metadata.files]
 alabaster = [
@@ -1331,12 +1331,12 @@ beautifulsoup4 = [
     {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
 ]
 boto3 = [
-    {file = "boto3-1.22.9-py3-none-any.whl", hash = "sha256:65e45029d234ff94ba8aa3bacb9df00fbbb2f1d9ee7fd1c2e40f4815d12ec3f5"},
-    {file = "boto3-1.22.9.tar.gz", hash = "sha256:441b619067cb205bfcd0e66fe085c16989ab65bd348823013e11bef991c00a5c"},
+    {file = "boto3-1.22.13-py3-none-any.whl", hash = "sha256:240931d41341f30d3cc0bba72ede4dbfe9704721bf13ca19bcd31a435c235f8d"},
+    {file = "boto3-1.22.13.tar.gz", hash = "sha256:02b6ad889f98c54274f83a4f862d78ce97a6366f805d8d8faaf14b789fd26172"},
 ]
 botocore = [
-    {file = "botocore-1.25.9-py3-none-any.whl", hash = "sha256:71962de55b053a0124a0514155f4cdcf0bce81795ffc2bd6e000c1594e99125a"},
-    {file = "botocore-1.25.9.tar.gz", hash = "sha256:a1d26b95aaa5b2e126df74b223d774fae7e6597bb55c363782178f5b87f0cad3"},
+    {file = "botocore-1.25.13-py3-none-any.whl", hash = "sha256:79b7773b48c9c59acd42ceba0a05b27ab9e326e9ed9b0ca35f41ad8abad61808"},
+    {file = "botocore-1.25.13.tar.gz", hash = "sha256:d99381bda4eed5896b74f6250132e2e6484c2d6e406b1def862113ffdb41c523"},
 ]
 cattrs = [
     {file = "cattrs-22.1.0-py3-none-any.whl", hash = "sha256:d55c477b4672f93606e992049f15d526dc7867e6c756cd6256d4af92e2b1e364"},
@@ -1772,12 +1772,12 @@ pygments = [
     {file = "Pygments-2.12.0.tar.gz", hash = "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb"},
 ]
 pyinaturalist = [
-    {file = "pyinaturalist-0.17.0dev5-py3-none-any.whl", hash = "sha256:d8c8018f3c2aedeb6820f844d3ebd95ad925d7c05f457a074b3aacbc1e96baed"},
-    {file = "pyinaturalist-0.17.0dev5.tar.gz", hash = "sha256:bf6155e9533ab71708da893d21155629c46235a98e2a48a44dcaddc0c8e0d6c3"},
+    {file = "pyinaturalist-0.17.0dev7-py3-none-any.whl", hash = "sha256:559e96aaf10c566644cb4129999649c2ef092399b0c674b598c650c031fbc9e1"},
+    {file = "pyinaturalist-0.17.0dev7.tar.gz", hash = "sha256:f78fbfa88f4adf67659b34927cd44498d343e216429e46db38714e7f0c20961e"},
 ]
 pyparsing = [
-    {file = "pyparsing-3.0.8-py3-none-any.whl", hash = "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"},
-    {file = "pyparsing-3.0.8.tar.gz", hash = "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954"},
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pyrate-limiter = [
     {file = "pyrate-limiter-2.8.1.tar.gz", hash = "sha256:0741b7db4b3facdce60bd836e0fcc43911bc52c443f674f924afba7e02e79c18"},
@@ -1861,8 +1861,8 @@ requests-cache = [
     {file = "requests_cache-1.0.0a0-py3-none-any.whl", hash = "sha256:a89d43f194801ce6152f7c736b78dfb78a8c66e6a85d8af6f999d2a860cc920f"},
 ]
 requests-ratelimiter = [
-    {file = "requests-ratelimiter-0.3.1.tar.gz", hash = "sha256:242363e9a37fd26251bce43983554ed1b600f66b9a4eacd8819bbbe96e3bd338"},
-    {file = "requests_ratelimiter-0.3.1-py3-none-any.whl", hash = "sha256:a8fd1145bf89a1ab72aa568d7d324eeb76a0d9c2cca60a69edb7551be72ef048"},
+    {file = "requests-ratelimiter-0.3.2.tar.gz", hash = "sha256:5bec149645b549135dadb701f8e0a97ecc3dcd40fa6504d55a68cc99e62a89af"},
+    {file = "requests_ratelimiter-0.3.2-py3-none-any.whl", hash = "sha256:8028309cba50480f91d04a78178f1a49ff22573632af2b79be91d73092994332"},
 ]
 rich = [
     {file = "rich-12.4.1-py3-none-any.whl", hash = "sha256:d13c6c90c42e24eb7ce660db397e8c398edd58acb7f92a2a88a95572b838aaa4"},

--- a/pyinat/__init__.py
+++ b/pyinat/__init__.py
@@ -1,0 +1,4 @@
+# flake8: noqa: F401, F403
+from pyinaturalist import *
+
+from pyinaturalist_convert import *

--- a/pyinaturalist_convert/__init__.py
+++ b/pyinaturalist_convert/__init__.py
@@ -5,10 +5,5 @@ from .csv import load_csv_exports
 from .dwc import to_dwc
 from .dwca import *
 from .geojson import to_geojson
+from .gpx import to_gpx
 from .odp import download_odp_metadata
-
-# Attempt to import additional modules with optional dependencies
-try:
-    from .gpx import to_gpx
-except ImportError as e:
-    to_gpx = lambda *args, **kwargs: print(e)  # type: ignore

--- a/pyinaturalist_convert/gpx.py
+++ b/pyinaturalist_convert/gpx.py
@@ -1,6 +1,5 @@
 from logging import getLogger
 
-from gpxpy.gpx import GPX, GPXTrack, GPXTrackPoint, GPXTrackSegment, GPXWaypoint
 from pyinaturalist import Observation
 from pyinaturalist.constants import ResponseResult
 from pyinaturalist.converters import convert_observation_timestamps
@@ -36,6 +35,9 @@ def to_gpx(observations: AnyObservations, filename: str = None, track: bool = Tr
     Returns:
         GPX XML as a string
     """
+
+    from gpxpy.gpx import GPX, GPXTrack, GPXTrackSegment
+
     gpx = GPX()
     points = [to_gpx_point(obs, track=track) for obs in to_dict_list(observations)]
 
@@ -63,6 +65,8 @@ def to_gpx_point(observation: ResponseResult, track: bool = True):
             otherwise, assume it is an unordered waypoint
 
     """
+    from gpxpy.gpx import GPXTrackPoint, GPXWaypoint
+
     logger.debug(f'Processing observation {observation["id"]}')
     observation = convert_observation_timestamps(observation)
     # GeoJSON coordinates are ordered as `longitude, latitude`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,15 @@ include = [
     { path = "examples", format = "sdist" },
     { path = "test", format = "sdist" }
 ]
+packages = [
+    { include = "pyinaturalist_convert" },
+    { include = "pyinat" },
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"
 geojson = ">=2.5"
-pyinaturalist = ">=0.17.0.dev4"  # TODO: stable release
+pyinaturalist = ">=0.17.0.dev7"  # TODO: stable release
 flatten-dict = "^0.4.0"
 tablib = "^3.0"
 tabulate = "^0.8.9"


### PR DESCRIPTION
This allows abbreviated imports from both pyinaturalist and pyinaturalist-convert, for example:
```python
from pyinat import iNatClient, to_csv
```